### PR TITLE
Use Shadow instead of Accessor

### DIFF
--- a/src/main/java/yeelp/distinctdamagedescriptions/mixin/MixinCombatTracker.java
+++ b/src/main/java/yeelp/distinctdamagedescriptions/mixin/MixinCombatTracker.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -21,8 +21,8 @@ import yeelp.distinctdamagedescriptions.util.lib.DebugLib;
 @Mixin(CombatTracker.class)
 public abstract class MixinCombatTracker {
 
-	@Accessor("fighter")
-	protected abstract EntityLivingBase getFighter();
+	@Shadow
+	public abstract EntityLivingBase getFighter();
 	
 	@Unique
 	private static final int TICK_DELTA = 50;


### PR DESCRIPTION
Why use an Accessor there? doesn't make sense.
Anyway the real reason I'm changing this is because I crash if I die in dev env with the mod as a dep because the game can't find the `getFighter` method. And since it started *after* I added DDD as a dep I have a sneaking suspicion this is the culprit